### PR TITLE
Bump version of axios to fix CVE-2024-28849

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "24.8.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.6.2",
+        "axios": "1.7.5",
         "form-data": "*",
         "jsonwebtoken": "9.0.1",
         "qs": "6.11.2"
@@ -244,11 +244,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:package": "npm pack"
   },
   "dependencies": {
-    "axios": "1.6.2",
+    "axios": "1.7.5",
     "form-data": "*",
     "jsonwebtoken": "9.0.1",
     "qs": "6.11.2"


### PR DESCRIPTION
This CVE is associated with `follow-redirects`, which is brought in by `axios`, so bumping `axios` to version 1.7.5 brings in the updated version of `follow-redirects` (1.15.6) without the vulnerability. This also resolves [another CVE here](https://github.com/groupdocs-conversion-cloud/groupdocs-conversion-cloud-node/issues/9).